### PR TITLE
Fix per gram calculation

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -32,10 +32,10 @@ EntriesCompanion calculateEntry({
   else
     quantityG = convertToGrams(quantity, unit);
 
-  final caloriesG = (food.calories ?? 0) / servingG;
-  final proteinG = (food.proteinG ?? 0) / servingG;
-  final fatG = (food.fatG ?? 0) / servingG;
-  final carbG = (food.carbohydrateG ?? 0) / servingG;
+  final caloriesG = (food.calories ?? 0) / 100;
+  final proteinG = (food.proteinG ?? 0) / 100;
+  final fatG = (food.fatG ?? 0) / 100;
+  final carbG = (food.carbohydrateG ?? 0) / 100;
 
   return entry.copyWith(
     kCalories: Value(quantityG * caloriesG),


### PR DESCRIPTION
Reference values are always per 100g, not per 1st serving value.

You can check it yourself, compare the values with what google finds about their nutrition.
![Screenshot_20240616_001609_Firefox](https://github.com/brandonp2412/FitBook/assets/53145267/e8953f90-4fcf-48a7-b136-20aecb51323e)
![Screenshot_20240616_001420](https://github.com/brandonp2412/FitBook/assets/53145267/42c07e67-61c8-41e1-a1cb-43de1d7a4e51)