### PR TITLE
fix: repair failing build-android and build-windows CI jobs

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=512m -XX:ActiveProcessorCount=8 -XX:+HeapDumpOnOutOfMemoryError
-org.gradle.java.home=/usr/lib/jvm/java-17-openjdk
 org.gradle.workers.max=6
 android.useAndroidX=true
 android.enableJetifier=true

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -32,6 +32,12 @@ set(CMAKE_CXX_FLAGS_PROFILE "${CMAKE_CXX_FLAGS_RELEASE}")
 # Use Unicode for all projects.
 add_definitions(-DUNICODE -D_UNICODE)
 
+# permission_handler_windows still includes <experimental/coroutine>, which
+# MSVC 14.51+ (VS 18.6+) turns into a hard error instead of a warning. Silence
+# it until the plugin migrates to <coroutine>.
+# https://github.com/flutter/flutter/issues/186452
+add_definitions(-D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 # Compilation settings that should be applied to most targets.
 #
 # Be cautious about adding new options here, as plugins use this function by


### PR DESCRIPTION
- Remove hardcoded org.gradle.java.home from android/gradle.properties;
  it pointed at a local dev machine path that doesn't exist on the CI
  runner, causing Gradle to fail with "Java home supplied is invalid".
  Gradle now picks up JAVA_HOME from the setup-java step instead.
- Define _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS in
  windows/CMakeLists.txt so permission_handler_windows still compiles
  under MSVC 14.51+ (VS 18.6+), which turns the old
  <experimental/coroutine> header into a hard error.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RnjKsjgmgSvPpL4LoEBheK