### PR TITLE
fix: remove kotlinOptions block incompatible with built-in Kotlin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -39,10 +39,6 @@ android {
         coreLibraryDesugaringEnabled true
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
android.builtInKotlin=true (enabled in a prior commit) uses AGP's new built-in Kotlin support, which no longer exposes android.kotlinOptions {} — Gradle failed with "Could not find method kotlinOptions()". The jvmTarget setting is unnecessary since built-in Kotlin already defaults it from android.compileOptions.targetCompatibility, which is set to 17.


Claude-Session: https://claude.ai/code/session_01RnjKsjgmgSvPpL4LoEBheK