### PR TITLE
Reduce churn in brittle widget tests

### DIFF
--- a/test/diary_page_test.dart
+++ b/test/diary_page_test.dart
@@ -4,14 +4,23 @@ import 'package:fit_book/diary/diary_page.dart';
 import 'package:fit_book/diary/diary_state.dart';
 import 'package:fit_book/main.dart';
 import 'package:fit_book/settings/settings_state.dart';
+import 'package:fit_book/speed_dial_fab.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
 import 'mock_tests.dart';
 
+Future<Food> _foodForDiary(int diaryId) async {
+  final diary = await (db.diaries.select()..where((d) => d.id.equals(diaryId)))
+      .getSingle();
+  return (db.foods.select()..where((food) => food.id.equals(diary.food!)))
+      .getSingle();
+}
+
 void main() async {
-  testWidgets('EntryPage CRUD', (WidgetTester tester) async {
+  testWidgets('DiaryPage persists create, edit and delete flows',
+      (WidgetTester tester) async {
     await mockTests();
     final settings = await (db.settings.select()).getSingle();
     final settingsState = SettingsState(settings);
@@ -30,16 +39,14 @@ void main() async {
       ),
     );
 
-    await (db.diaries.insertAll(
-      [
-        DiariesCompanion.insert(
-          food: Value(food1Id),
-          created: DateTime.now(),
-          quantity: 1,
-          unit: 'grams',
-        ),
-      ],
-    ));
+    final originalDiaryId = await db.diaries.insertOne(
+      DiariesCompanion.insert(
+        food: Value(food1Id),
+        created: DateTime.now(),
+        quantity: 1,
+        unit: 'grams',
+      ),
+    );
 
     await tester.pumpWidget(
       MultiProvider(
@@ -47,17 +54,15 @@ void main() async {
           ChangeNotifierProvider(create: (context) => settingsState),
           ChangeNotifierProvider(create: (context) => DiaryState()),
         ],
-        child: const MaterialApp(
-          home: DiaryPage(),
-        ),
+        child: const MaterialApp(home: DiaryPage()),
       ),
     );
     await tester.pumpAndSettle();
     expect(find.text('Test 1'), findsOne);
 
-    await tester.tap(find.text('Add'));
+    await tester.tap(find.byType(SpeedDialFab));
     await tester.pumpAndSettle();
-    expect(find.text('Add diary entry'), findsOne);
+    expect(find.byKey(const Key('name_field')), findsOne);
 
     await tester.enterText(find.byKey(const Key('name_field')), 'Test 4');
     await tester.pumpAndSettle();
@@ -73,25 +78,35 @@ void main() async {
     await tester.tap(find.byTooltip('Save'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Add'), findsOne);
-    expect(find.text('Test 4'), findsOne);
+    final afterCreate = await db.diaries.select().get();
+    expect(afterCreate, hasLength(2));
+    final createdDiary =
+        afterCreate.singleWhere((diary) => diary.id != originalDiaryId);
+    expect((await _foodForDiary(createdDiary.id)).name, 'Test 4');
 
     await tester.tap(find.text('Test 4'));
     await tester.pumpAndSettle();
-    expect(find.text('Edit diary entry'), findsOne);
+    final nameField = tester.widget<TextField>(
+      find.byKey(const Key('name_field')),
+    );
+    expect(nameField.controller!.text, 'Test 4');
+
     await tester.enterText(find.byKey(const Key('name_field')), 'Test 5');
     await tester.pumpAndSettle();
     await tester.tap(find.byTooltip('Save'));
     await tester.pumpAndSettle();
-    expect(find.text('Test 5'), findsOne);
+    expect((await _foodForDiary(createdDiary.id)).name, 'Test 5');
 
     await tester.longPress(find.text('Test 5'));
     await tester.pumpAndSettle();
     await tester.tap(find.byTooltip('Delete'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('Delete'));
+    await tester.tap(find.widgetWithText(TextButton, 'Delete'));
     await tester.pumpAndSettle();
-    expect(find.text('Test 5'), findsNothing);
+
+    final afterDelete = await db.diaries.select().get();
+    expect(afterDelete, hasLength(1));
+    expect(afterDelete.single.id, originalDiaryId);
 
     await db.close();
   });

--- a/test/edit_diary_test.dart
+++ b/test/edit_diary_test.dart
@@ -18,13 +18,20 @@ Widget _wrap(Widget child, SettingsState settingsState) => MultiProvider(
       child: MaterialApp(home: child),
     );
 
+Finder _fieldStarting(String label) => find.byWidgetPredicate(
+      (widget) =>
+          widget is TextField &&
+          widget.decoration?.labelText?.startsWith(label) == true,
+    );
+
 void main() async {
-  testWidgets('EditDiary updates', (WidgetTester tester) async {
+  testWidgets('EditDiary persists nutrient updates',
+      (WidgetTester tester) async {
     await mockTests();
     final settings = await (db.settings.select()).getSingle();
     final settingsState = SettingsState(settings);
 
-    final foodId = await (db.foods.insertOne(
+    final foodId = await db.foods.insertOne(
       FoodsCompanion.insert(
         name: 'Hamburger',
         calories: const Value(240),
@@ -32,52 +39,33 @@ void main() async {
         carbohydrateG: const Value(3),
         fatG: const Value(4),
       ),
-    ));
-    final entryId = await (db.diaries.insertOne(
+    );
+    final entryId = await db.diaries.insertOne(
       DiariesCompanion.insert(
         food: Value(foodId),
         created: DateTime.now(),
         quantity: 1,
         unit: 'serving',
       ),
-    ));
+    );
 
     await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          ChangeNotifierProvider(create: (context) => settingsState),
-          ChangeNotifierProvider(create: (context) => DiaryState()),
-        ],
-        child: MaterialApp(
-          home: EditDiaryPage(
-            id: entryId,
-          ),
-        ),
-      ),
+      _wrap(EditDiaryPage(id: entryId), settingsState),
     );
-    await tester.pump();
-    expect(find.text('Edit diary entry'), findsOne);
-    expect(find.text('Hamburger'), findsOne);
+    await tester.pumpAndSettle();
 
-    await tester.enterText(
-      find.bySemanticsLabel('Calories (per 100.0 g)'),
-      '601',
-    );
-    await tester.pump();
-    expect(find.text('601'), findsOne);
-
-    await tester.enterText(
-      find.bySemanticsLabel('Protein (per 100.0 g)'),
-      '41',
-    );
-    await tester.pump();
-    expect(find.text('41'), findsOne);
-
+    await tester.enterText(_fieldStarting('Calories'), '601');
+    await tester.enterText(_fieldStarting('Protein'), '41');
     tester.testTextInput.hide();
     await tester.pumpAndSettle();
-    await tester.tap(find.byType(FloatingActionButton));
-    await tester.pump();
-    expect(find.text('Add diary entry'), findsNothing);
+    await tester.tap(find.byTooltip('Save'));
+    await tester.pumpAndSettle();
+
+    final savedFood = await (db.foods.select()
+          ..where((food) => food.id.equals(foodId)))
+        .getSingle();
+    expect(savedFood.calories, 601);
+    expect(savedFood.proteinG, 41);
 
     await db.close();
   });
@@ -88,10 +76,9 @@ void main() async {
     final settings = await (db.settings.select()).getSingle();
     final settingsState = SettingsState(settings);
 
-    // 1. Create a Food in the database with specific servingSize and servingUnit
-    const double initialServingSize = 250.0;
-    const String initialServingUnit = 'ml';
-    final foodId = await (db.foods.insertOne(
+    const initialServingSize = 250.0;
+    const initialServingUnit = 'ml';
+    final foodId = await db.foods.insertOne(
       FoodsCompanion.insert(
         name: 'Pure Premium Orange Juice Calcium And Vitamin D No Pulp',
         calories: const Value(110),
@@ -101,67 +88,41 @@ void main() async {
         carbohydrateG: const Value(3),
         fatG: const Value(4),
       ),
-    ));
-    final entryId = await (db.diaries.insertOne(
+    );
+    final entryId = await db.diaries.insertOne(
       DiariesCompanion.insert(
         food: Value(foodId),
         created: DateTime.now(),
         quantity: 1,
         unit: 'serving',
       ),
-    ));
+    );
 
     await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          ChangeNotifierProvider(create: (context) => settingsState),
-          ChangeNotifierProvider(create: (context) => DiaryState()),
-        ],
-        child: MaterialApp(
-          home: EditDiaryPage(
-            id: entryId,
-          ),
-        ),
-      ),
+      _wrap(EditDiaryPage(id: entryId), settingsState),
     );
     await tester.pumpAndSettle();
-    expect(find.text('Edit diary entry'), findsOne);
-    expect(
-      find.text('Pure Premium Orange Juice Calcium And Vitamin D No Pulp'),
-      findsOne,
-    );
 
-    // 2. Change the quantity in the quantity text field
-    const String newQuantity = '3.5';
+    const newQuantity = '3.5';
     await tester.enterText(find.bySemanticsLabel('Quantity'), newQuantity);
-    await tester.pumpAndSettle();
-
-    // 3. Change the name to trigger the 'foodDirty' and new food insertion logic
-    final Finder nameField = find.bySemanticsLabel('Name');
     await tester.enterText(
-      nameField,
+      find.byKey(const Key('name_field')),
       'Pure Premium Orange Juice Calcium And Vitamin D No Pulp (Edited)',
     );
     await tester.pump();
+    await tester.tap(find.byTooltip('Save'));
+    await tester.pumpAndSettle();
 
-    // 4. Tap the save button
-    await tester.tap(find.byType(FloatingActionButton));
-    await tester.pumpAndSettle(); // Wait for navigation to complete
-
-    // 5. Query the database for the saved food and entry
     final updatedEntry = await (db.diaries.select()
-          ..where((e) => e.id.equals(entryId)))
+          ..where((entry) => entry.id.equals(entryId)))
         .getSingle();
     final savedFood = await (db.foods.select()
-          ..where((f) => f.id.equals(updatedEntry.food!)))
+          ..where((food) => food.id.equals(updatedEntry.food!)))
         .getSingle();
 
-    // 6. Assert that the saved food's servingSize and servingUnit are still the original values
-    expect(savedFood.servingSize, equals(initialServingSize));
-    expect(savedFood.servingUnit, equals(initialServingUnit));
-
-    // 7. Assert that the entry quantity is the new quantity entered by the user
-    expect(updatedEntry.quantity, equals(double.parse(newQuantity)));
+    expect(savedFood.servingSize, initialServingSize);
+    expect(savedFood.servingUnit, initialServingUnit);
+    expect(updatedEntry.quantity, double.parse(newQuantity));
 
     await db.close();
   });
@@ -179,13 +140,9 @@ void main() async {
 
     await tester.pumpWidget(_wrap(const EditDiaryPage(), settingsState));
     await tester.pumpAndSettle();
-    expect(find.text('Add diary entry'), findsOne);
 
-    // Search for the meal by typing in the name field
     await tester.enterText(find.byKey(const Key('name_field')), 'Chicken');
     await tester.pumpAndSettle();
-
-    // Tap the 'Meal' subtitle result (the meal tile)
     await tester.tap(
       find
           .ancestor(
@@ -195,15 +152,11 @@ void main() async {
           .first,
     );
     await tester.pumpAndSettle();
-
-    expect(find.text('Chicken Bowl'), findsOne);
-
-    // Save
-    await tester.tap(find.byType(FloatingActionButton));
+    await tester.tap(find.byTooltip('Save'));
     await tester.pumpAndSettle();
 
     final entries = await db.diaries.select().get();
-    expect(entries.length, 1);
+    expect(entries, hasLength(1));
     expect(entries.first.meal, mealId);
     expect(entries.first.food, isNull);
 
@@ -234,16 +187,10 @@ void main() async {
     await tester.pumpWidget(_wrap(EditDiaryPage(id: entryId), settingsState));
     await tester.pumpAndSettle();
 
-    expect(find.text('Edit diary entry'), findsOne);
-    expect(find.text('Breakfast Bowl'), findsOne);
-
-    // Clear and type to search for the second meal
     await tester.tap(find.byIcon(Icons.close));
     await tester.pumpAndSettle();
-
     await tester.enterText(find.byKey(const Key('name_field')), 'Lunch');
     await tester.pumpAndSettle();
-
     await tester.tap(
       find
           .ancestor(
@@ -253,12 +200,11 @@ void main() async {
           .first,
     );
     await tester.pumpAndSettle();
-
-    await tester.tap(find.byType(FloatingActionButton));
+    await tester.tap(find.byTooltip('Save'));
     await tester.pumpAndSettle();
 
     final updated = await (db.diaries.select()
-          ..where((t) => t.id.equals(entryId)))
+          ..where((entry) => entry.id.equals(entryId)))
         .getSingle();
     expect(updated.meal, meal2Id);
     expect(updated.food, isNull);
@@ -294,19 +240,16 @@ void main() async {
     await tester.pumpWidget(_wrap(EditDiaryPage(id: entryId), settingsState));
     await tester.pumpAndSettle();
 
-    await tester.tap(
-      find.byWidgetPredicate(
-        (widget) =>
-            widget is InkWell &&
-            widget.child is SizedBox &&
-            (widget.child as SizedBox).height == 200,
-      ),
+    final imageTarget = find.ancestor(
+      of: find.text('Image error'),
+      matching: find.byType(InkWell),
     );
+    expect(imageTarget, findsOne);
+    await tester.tap(imageTarget);
     await tester.pumpAndSettle();
     await tester.tap(find.text('Delete image'));
     await tester.pumpAndSettle();
-
-    await tester.tap(find.byType(FloatingActionButton));
+    await tester.tap(find.byTooltip('Save'));
     await tester.pumpAndSettle();
 
     final updatedMeal = await (db.meals.select()
@@ -343,17 +286,13 @@ void main() async {
     await tester.pumpWidget(_wrap(EditDiaryPage(id: entryId), settingsState));
     await tester.pumpAndSettle();
 
-    expect(find.text('Edit diary entry'), findsOne);
-    expect(find.text('Oatmeal'), findsOne);
-
     await tester.enterText(find.bySemanticsLabel('Quantity'), '250');
     await tester.pump();
-
-    await tester.tap(find.byType(FloatingActionButton));
+    await tester.tap(find.byTooltip('Save'));
     await tester.pumpAndSettle();
 
     final updated = await (db.diaries.select()
-          ..where((t) => t.id.equals(entryId)))
+          ..where((entry) => entry.id.equals(entryId)))
         .getSingle();
     expect(updated.quantity, 250.0);
     expect(updated.food, foodId);
@@ -379,7 +318,9 @@ void main() async {
     );
     await tester.pumpAndSettle();
 
-    final quantity = tester.widget<TextField>(find.byType(TextField).at(1));
+    final quantity = tester.widget<TextField>(
+      find.bySemanticsLabel('Quantity'),
+    );
     expect(quantity.controller!.text, '1');
 
     await db.close();

--- a/test/graph_page_test.dart
+++ b/test/graph_page_test.dart
@@ -12,58 +12,47 @@ import 'package:provider/provider.dart';
 
 import 'mock_tests.dart';
 
+Future<void> _selectMetric(WidgetTester tester, String metric) async {
+  final picker = tester.widget<DropdownButton<String>>(
+    find.byType(DropdownButton<String>),
+  );
+  expect(picker.items!.map((item) => item.value), contains(metric));
+  picker.onChanged!(metric);
+  await tester.pumpAndSettle();
+
+  final updatedPicker = tester.widget<DropdownButton<String>>(
+    find.byType(DropdownButton<String>),
+  );
+  expect(updatedPicker.value, metric);
+}
+
 void main() async {
-  testWidgets('GraphPage diaries', (WidgetTester tester) async {
+  testWidgets('GraphPage renders diary metrics', (WidgetTester tester) async {
     await mockTests();
     final settings = await (db.settings.select()).getSingle();
     final settingsState = SettingsState(settings);
+    final now = DateTime.now();
 
-    await (db.diaries.insertAll(
-      [
+    for (var i = 0; i < 3; i++) {
+      final foodId = await db.foods.insertOne(
+        FoodsCompanion.insert(
+          name: 'Test ${i + 1}',
+          calories: Value(100 + i.toDouble()),
+          proteinG: Value(20 + i.toDouble()),
+          fatG: Value(10 + i.toDouble()),
+          carbohydrateG: Value(30 + i.toDouble()),
+          servingWeight1G: const Value(1),
+        ),
+      );
+      await db.diaries.insertOne(
         DiariesCompanion.insert(
-          food: Value(
-            await (db.foods.insertOne(
-              FoodsCompanion.insert(
-                name: 'Test 3',
-                calories: const Value(1),
-                servingWeight1G: const Value(1),
-              ),
-            )),
-          ),
-          created: DateTime.now(),
+          food: Value(foodId),
+          created: now.subtract(Duration(days: i)),
           quantity: 1,
           unit: 'serving',
         ),
-        DiariesCompanion.insert(
-          food: Value(
-            await (db.foods.insertOne(
-              FoodsCompanion.insert(
-                name: 'Test 2',
-                calories: const Value(1),
-                servingWeight1G: const Value(1),
-              ),
-            )),
-          ),
-          created: DateTime.now().subtract(const Duration(days: 1)),
-          quantity: 1,
-          unit: 'serving',
-        ),
-        DiariesCompanion.insert(
-          food: Value(
-            await (db.foods.insertOne(
-              FoodsCompanion.insert(
-                name: 'Test 1',
-                calories: const Value(1),
-                servingWeight1G: const Value(1),
-              ),
-            )),
-          ),
-          created: DateTime.now().subtract(const Duration(days: 2)),
-          quantity: 1,
-          unit: 'serving',
-        ),
-      ],
-    ));
+      );
+    }
 
     await tester.pumpWidget(
       MultiProvider(
@@ -71,29 +60,19 @@ void main() async {
           ChangeNotifierProvider(create: (context) => settingsState),
           ChangeNotifierProvider(create: (context) => DiaryState()),
         ],
-        child: const MaterialApp(
-          home: GraphPage(),
-        ),
+        child: const MaterialApp(home: GraphPage()),
       ),
     );
-    await tester.pump();
-    await tester.tap(find.text('Calories'));
-    await tester.pump();
-    await tester.tap(find.text('Protein'));
     await tester.pumpAndSettle();
-    expect(find.byType(LineChart), findsOne);
 
-    await tester.tap(find.text('Protein'));
-    await tester.pump();
-    await tester.tap(find.text('Fat g'));
-    await tester.pumpAndSettle();
-    expect(find.byType(LineChart), findsOne);
-
-    await tester.tap(find.text('Fat g'));
-    await tester.pump();
-    await tester.tap(find.text('Carbohydrate g'));
-    await tester.pumpAndSettle();
-    expect(find.byType(LineChart), findsOne);
+    for (final metric in [
+      db.foods.proteinG.name,
+      db.foods.fatG.name,
+      db.foods.carbohydrateG.name,
+    ]) {
+      await _selectMetric(tester, metric);
+      expect(find.byType(LineChart), findsOne);
+    }
 
     await db.close();
   });
@@ -123,7 +102,6 @@ void main() async {
         unit: 'serving',
       ),
     );
-    // Add a meal diary entry (food is NULL — previously excluded by innerJoin).
     await db.diaries.insertOne(
       DiariesCompanion.insert(
         meal: Value(mealId),
@@ -144,37 +122,33 @@ void main() async {
     );
     await tester.pumpAndSettle();
 
-    // The chart should render with data rather than showing "No data yet".
     expect(find.text('No data yet'), findsNothing);
     expect(find.byType(LineChart), findsOne);
 
     await db.close();
   });
 
-  testWidgets('GraphPage body weight', (WidgetTester tester) async {
+  testWidgets('GraphPage renders body weight', (WidgetTester tester) async {
     await mockTests();
     final settings = await (db.settings.select()).getSingle();
     final settingsState = SettingsState(settings);
+    final now = DateTime.now();
 
-    await (db.weights.insertAll(
+    await db.weights.insertAll(
       [
+        WeightsCompanion.insert(created: now, unit: 'kg', amount: 60),
         WeightsCompanion.insert(
-          created: DateTime.now(),
-          unit: 'kg',
-          amount: 60,
-        ),
-        WeightsCompanion.insert(
-          created: DateTime.now().subtract(const Duration(days: 1)),
+          created: now.subtract(const Duration(days: 1)),
           unit: 'kg',
           amount: 70,
         ),
         WeightsCompanion.insert(
-          created: DateTime.now().subtract(const Duration(days: 2)),
+          created: now.subtract(const Duration(days: 2)),
           unit: 'kg',
           amount: 80,
         ),
       ],
-    ));
+    );
 
     await tester.pumpWidget(
       MultiProvider(
@@ -182,22 +156,18 @@ void main() async {
           ChangeNotifierProvider(create: (context) => settingsState),
           ChangeNotifierProvider(create: (context) => DiaryState()),
         ],
-        child: const MaterialApp(
-          home: GraphPage(),
-        ),
+        child: const MaterialApp(home: GraphPage()),
       ),
     );
-    await tester.pump();
-    await tester.tap(find.text('Calories'));
-    await tester.pump();
-    await tester.tap(find.text('Body weight'));
     await tester.pumpAndSettle();
+
+    await _selectMetric(tester, 'body-weight');
     expect(find.byType(LineChart), findsOne);
 
     await db.close();
   });
 
-  testWidgets('GraphPage defaults calories to weekly',
+  testWidgets('GraphPage defaults to calories grouped weekly',
       (WidgetTester tester) async {
     await mockTests();
     final settings = await (db.settings.select()).getSingle();
@@ -214,10 +184,9 @@ void main() async {
     );
     await tester.pump();
 
-    final periodPicker = tester.widget<SegmentedButton<Period>>(
-      find.byType(SegmentedButton<Period>),
-    );
-    expect(periodPicker.selected, {Period.week});
+    final state = tester.state<GraphPageState>(find.byType(GraphPage));
+    expect(state.metric, db.foods.calories.name);
+    expect(state.groupBy, Period.week);
 
     await db.close();
   });

--- a/test/settings_page_test.dart
+++ b/test/settings_page_test.dart
@@ -1,3 +1,4 @@
+import 'package:drift/drift.dart';
 import 'package:fit_book/diary/diary_state.dart';
 import 'package:fit_book/main.dart';
 import 'package:fit_book/settings/appearance_settings.dart';

--- a/test/settings_page_test.dart
+++ b/test/settings_page_test.dart
@@ -1,115 +1,85 @@
-import 'package:drift/drift.dart';
 import 'package:fit_book/diary/diary_state.dart';
 import 'package:fit_book/main.dart';
+import 'package:fit_book/settings/appearance_settings.dart';
+import 'package:fit_book/settings/data_settings.dart';
+import 'package:fit_book/settings/diary_settings.dart';
+import 'package:fit_book/settings/food_settings.dart';
 import 'package:fit_book/settings/settings_page.dart';
 import 'package:fit_book/settings/settings_state.dart';
+import 'package:fit_book/settings/tab_settings.dart';
+import 'package:fit_book/settings/weight_settings.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
 import 'mock_tests.dart';
 
+Future<SettingsState> _settingsState() async =>
+    SettingsState(await db.settings.select().getSingle());
+
+Widget _wrap(SettingsState settingsState) => MultiProvider(
+      providers: [
+        ChangeNotifierProvider(create: (_) => settingsState),
+        ChangeNotifierProvider(create: (_) => DiaryState()),
+      ],
+      child: const MaterialApp(home: SettingsPage()),
+    );
+
 void main() async {
-  testWidgets('SettingsPage', (WidgetTester tester) async {
+  testWidgets('SettingsPage search filters categories',
+      (WidgetTester tester) async {
     await mockTests();
-    final settings = await (db.settings.select()).getSingle();
-    final settingsState = SettingsState(settings);
-
-    await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          ChangeNotifierProvider(create: (context) => settingsState),
-          ChangeNotifierProvider(create: (context) => DiaryState()),
-        ],
-        child: const MaterialApp(
-          home: SettingsPage(),
-        ),
-      ),
-    );
-    await tester.pumpAndSettle();
-
-    expect(find.text('Appearance'), findsOne);
-    expect(find.text('Data'), findsOne);
-    expect(find.text('Diary'), findsOne);
-    expect(find.text('Food'), findsOne);
-    expect(find.text('Weight'), findsOne);
-
-    await db.close();
-  });
-
-  testWidgets('SettingsPage search', (WidgetTester tester) async {
-    await mockTests();
-    final settings = await (db.settings.select()).getSingle();
-    final settingsState = SettingsState(settings);
-
-    await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          ChangeNotifierProvider(create: (context) => settingsState),
-          ChangeNotifierProvider(create: (context) => DiaryState()),
-        ],
-        child: const MaterialApp(
-          home: SettingsPage(),
-        ),
-      ),
-    );
+    await tester.pumpWidget(_wrap(await _settingsState()));
     await tester.pumpAndSettle();
 
     await tester.enterText(find.bySemanticsLabel('Search...'), 'Weight');
     await tester.pumpAndSettle();
+
     expect(find.text('Weight'), findsOne);
     expect(find.text('Appearance'), findsNothing);
 
     await db.close();
   });
 
-  testWidgets('SettingsPage navigates', (WidgetTester tester) async {
+  testWidgets('SettingsPage opens each settings section',
+      (WidgetTester tester) async {
     await mockTests();
-    final settings = await (db.settings.select()).getSingle();
-    final settingsState = SettingsState(settings);
-
-    await tester.pumpWidget(
-      MultiProvider(
-        providers: [
-          ChangeNotifierProvider(create: (context) => settingsState),
-          ChangeNotifierProvider(create: (context) => DiaryState()),
-        ],
-        child: const MaterialApp(
-          home: SettingsPage(),
-        ),
-      ),
-    );
+    await tester.pumpWidget(_wrap(await _settingsState()));
+    await tester.pumpAndSettle();
 
     await tester.tap(find.text('Appearance'));
     await tester.pumpAndSettle();
-    expect(find.text('System'), findsOne);
-    expect(find.text('Navigation animation'), findsOne);
-    await tester.tap(find.byTooltip('Back'));
+    expect(find.byType(AppearanceSettings), findsOne);
+    await tester.pageBack();
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Data'));
     await tester.pumpAndSettle();
-    expect(find.text('Export data'), findsOne);
-    await tester.tap(find.byTooltip('Back'));
+    expect(find.byType(DataSettings), findsOne);
+    await tester.pageBack();
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Diary'));
     await tester.pumpAndSettle();
-    expect(find.bySemanticsLabel('Daily calories (kcal)'), findsOne);
-    await tester.tap(find.byTooltip('Back'));
+    expect(find.byType(DiarySettings), findsOne);
+    await tester.pageBack();
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Food'));
     await tester.pumpAndSettle();
-    expect(find.text('Food unit'), findsOne);
-    await tester.tap(find.byTooltip('Back'));
+    expect(find.byType(FoodSettings), findsOne);
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Tabs'));
+    await tester.pumpAndSettle();
+    expect(find.byType(TabSettings), findsOne);
+    await tester.pageBack();
     await tester.pumpAndSettle();
 
     await tester.tap(find.text('Weight'));
     await tester.pumpAndSettle();
-    expect(find.text('Target weight'), findsOne);
-    await tester.tap(find.byTooltip('Back'));
-    await tester.pumpAndSettle();
+    expect(find.byType(WeightSettings), findsOne);
 
     await db.close();
   });

--- a/test/weight_page_test.dart
+++ b/test/weight_page_test.dart
@@ -11,186 +11,51 @@ import 'package:provider/provider.dart';
 import 'mock_tests.dart';
 
 void main() async {
-  testWidgets(
-    'WeightPage list',
-    (WidgetTester tester) async {
-      await mockTests();
-      final settings = await (db.settings.select()).getSingle();
-      final settingsState = SettingsState(settings);
+  testWidgets('WeightPage deletes selected weights',
+      (WidgetTester tester) async {
+    await mockTests();
+    final settings = await (db.settings.select()).getSingle();
+    final settingsState = SettingsState(settings);
+    final now = DateTime.now();
 
-      await (db.weights.insertAll(
-        [
-          WeightsCompanion.insert(
-            created: DateTime.now(),
-            unit: 'kg',
-            amount: 60,
-          ),
-          WeightsCompanion.insert(
-            created: DateTime.now().subtract(const Duration(days: 1)),
-            unit: 'kg',
-            amount: 70,
-          ),
-          WeightsCompanion.insert(
-            created: DateTime.now().subtract(const Duration(days: 2)),
-            unit: 'kg',
-            amount: 80,
-          ),
+    await db.weights.insertAll(
+      [
+        WeightsCompanion.insert(created: now, unit: 'kg', amount: 60),
+        WeightsCompanion.insert(
+          created: now.subtract(const Duration(days: 1)),
+          unit: 'kg',
+          amount: 70,
+        ),
+        WeightsCompanion.insert(
+          created: now.subtract(const Duration(days: 2)),
+          unit: 'kg',
+          amount: 80,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (context) => settingsState),
+          ChangeNotifierProvider(create: (context) => DiaryState()),
         ],
-      ));
+        child: const MaterialApp(home: WeightPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
 
-      await tester.pumpWidget(
-        MultiProvider(
-          providers: [
-            ChangeNotifierProvider(create: (context) => settingsState),
-            ChangeNotifierProvider(create: (context) => DiaryState()),
-          ],
-          child: const MaterialApp(
-            home: WeightPage(),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
+    await tester.longPress(find.textContaining('60'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.textContaining('70'));
+    await tester.tap(find.textContaining('80'));
+    await tester.tap(find.byTooltip('Delete'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(TextButton, 'Delete'));
+    await tester.pumpAndSettle();
 
-      expect(find.textContaining('60'), findsOne);
-      expect(find.textContaining('70'), findsOne);
-      expect(find.textContaining('80'), findsOne);
+    expect(await db.weights.select().get(), isEmpty);
 
-      await db.close();
-    },
-  );
-
-  testWidgets(
-    'WeightPage update',
-    (WidgetTester tester) async {
-      await mockTests();
-      final settings = await (db.settings.select()).getSingle();
-      final settingsState = SettingsState(settings);
-
-      await (db.weights.insertAll(
-        [
-          WeightsCompanion.insert(
-            created: DateTime.now(),
-            unit: 'kg',
-            amount: 60,
-          ),
-        ],
-      ));
-
-      await tester.pumpWidget(
-        MultiProvider(
-          providers: [
-            ChangeNotifierProvider(create: (context) => settingsState),
-            ChangeNotifierProvider(create: (context) => DiaryState()),
-          ],
-          child: const MaterialApp(
-            home: WeightPage(),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.textContaining('60'), findsOne);
-      await tester.tap(find.text('60.0kg'));
-      await tester.pumpAndSettle();
-      expect(find.text('Edit weight'), findsOne);
-
-      await tester.enterText(find.bySemanticsLabel('Weight (kg)'), '61');
-      await tester.tap(find.text('Save'));
-      await tester.pumpAndSettle();
-      expect(find.text('61.0kg'), findsOne);
-
-      await db.close();
-    },
-  );
-
-  testWidgets(
-    'WeightPage delete',
-    (WidgetTester tester) async {
-      await mockTests();
-      final settings = await (db.settings.select()).getSingle();
-      final settingsState = SettingsState(settings);
-
-      await (db.weights.insertAll(
-        [
-          WeightsCompanion.insert(
-            created: DateTime.now(),
-            unit: 'kg',
-            amount: 60,
-          ),
-          WeightsCompanion.insert(
-            created: DateTime.now().subtract(const Duration(days: 1)),
-            unit: 'kg',
-            amount: 70,
-          ),
-          WeightsCompanion.insert(
-            created: DateTime.now().subtract(const Duration(days: 2)),
-            unit: 'kg',
-            amount: 80,
-          ),
-        ],
-      ));
-
-      await tester.pumpWidget(
-        MultiProvider(
-          providers: [
-            ChangeNotifierProvider(create: (context) => settingsState),
-            ChangeNotifierProvider(create: (context) => DiaryState()),
-          ],
-          child: const MaterialApp(
-            home: WeightPage(),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.textContaining('60'), findsOne);
-      await tester.longPress(find.textContaining('60'));
-      await tester.pumpAndSettle();
-      await tester.tap(find.textContaining('70'));
-      await tester.tap(find.textContaining('80'));
-      await tester.tap(find.byTooltip('Delete'));
-      await tester.pump();
-      expect(find.textContaining('Are you sure'), findsOne);
-      await tester.tap(find.text('Delete'));
-
-      await tester.pumpAndSettle();
-      expect(find.text('No weights found'), findsOne);
-
-      await db.close();
-    },
-  );
-
-  testWidgets(
-    'WeightPage create',
-    (WidgetTester tester) async {
-      await mockTests();
-      final settings = await (db.settings.select()).getSingle();
-      final settingsState = SettingsState(settings);
-
-      await tester.pumpWidget(
-        MultiProvider(
-          providers: [
-            ChangeNotifierProvider(create: (context) => settingsState),
-            ChangeNotifierProvider(create: (context) => DiaryState()),
-          ],
-          child: const MaterialApp(
-            home: WeightPage(),
-          ),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      expect(find.text('No weights found'), findsOne);
-      await tester.tap(find.text('Add'));
-      await tester.pumpAndSettle();
-      await tester.enterText(find.bySemanticsLabel('Weight (kg)'), '61');
-      await tester.testTextInput.receiveAction(TextInputAction.done);
-      await tester.pumpAndSettle();
-
-      final weight = await (db.weights.select()).getSingle();
-      expect(weight.amount, equals(61));
-
-      await db.close();
-    },
-  );
+    await db.close();
+  });
 }


### PR DESCRIPTION
Audits the highest-churn current test files and removes avoidable churn.

- `diary_page_test.dart` — 15 current-path revisions: assert persisted CRUD state instead of page copy where possible.
- `graph_page_test.dart` — 14: select metrics by stable database identifiers rather than display labels, and assert default `GraphPageState` directly.
- `settings_page_test.dart` — 11: remove redundant category-copy coverage and verify navigation by destination widget type rather than internal page text.
- `mock_tests.dart` — 11: audited but intentionally unchanged; this is the shared fixture boundary and its churn is primarily schema/default-setting evolution, which belongs in one central helper.
- `weight_page_test.dart` — 10: remove redundant list/create/update presentation tests already covered by `edit_weight_page_test.dart`; keep the unique multi-select delete flow and assert database state.
- `edit_diary_test.dart` — 10: replace exact dynamic nutrient labels and fixed widget geometry with behavior-oriented finders; strengthen the nutrient test to verify persisted values.

No production behavior changes.